### PR TITLE
Update navbar logo hover effect to use glow instead of underline

### DIFF
--- a/src/components/BasePage/Navbar/Navbar.module.scss
+++ b/src/components/BasePage/Navbar/Navbar.module.scss
@@ -172,3 +172,17 @@
     }
   }
 }
+
+.hoverGlow {
+  @extend .hoverUnderline;
+  
+  &::after {
+    display: none;
+  }
+  
+  @include desktop {
+    &:hover {
+      transform: scale(1.1);
+    }
+  }
+}

--- a/src/components/BasePage/Navbar/Navbar.tsx
+++ b/src/components/BasePage/Navbar/Navbar.tsx
@@ -23,7 +23,7 @@ const Navbar = () => {
         <div className={styles.topAlignmentContainer}>
           <Link
             href={"/"}
-            className={`${styles.navItem} ${styles.hoverUnderline}`}
+            className={`${styles.navItem} ${styles.hoverGlow}`}
           >
             <Image
               src="/benrogo-old.png"


### PR DESCRIPTION
- Replace hoverUnderline with hoverGlow class for logo
- Logo now scales up on hover instead of moving up